### PR TITLE
Fix BigDecimal.new deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ utilities.
 
 Prefer [LESS](http://lesscss.org)? No problem, you'll just need to create a
 [Gemfile like this one](https://gist.github.com/mattwigham/5569898) in the
-root directory of your theme, run ```bundle install```, and append the
+root directory of your theme, run `bundle install`, and append the
 **.less** extension to your CSS files.
 
 And finally, for you JavaScript folks, we've baked

--- a/lib/dugway/liquid/filters/util_filters.rb
+++ b/lib/dugway/liquid/filters/util_filters.rb
@@ -86,13 +86,13 @@ module Dugway
             digits, rounded_number = 1, 0
           else
             digits = (Math.log10(number.abs) + 1).floor
-            rounded_number = (BigDecimal.new(number.to_s) / BigDecimal.new((10 ** (digits - precision)).to_f.to_s)).round.to_f * 10 ** (digits - precision)
+            rounded_number = (BigDecimal(number.to_s) / BigDecimal((10 ** (digits - precision)).to_f.to_s)).round.to_f * 10 ** (digits - precision)
             digits = (Math.log10(rounded_number.abs) + 1).floor # After rounding, the number of digits may have changed
           end
           precision -= digits
           precision = precision > 0 ? precision : 0  #don't let it be negative
         else
-          rounded_number = BigDecimal.new(number.to_s).round(precision).to_f
+          rounded_number = BigDecimal(number.to_s).round(precision).to_f
         end
         formatted_number = number_with_delimiter("%01.#{precision}f" % rounded_number, options)
         if strip_insignificant_zeros


### PR DESCRIPTION
When using Dugway on Ruby 2.6.0, the following deprecation warning is 
thrown:

```
warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

This reworks the use of `BigDecimal` based on this deprecation warning. I confirmed this fixes the issue when using this new gem version locally.

Fixes https://github.com/bigcartel/dugway/issues/170