### PR TITLE
Remove contact tabindex

### DIFF
--- a/lib/dugway/liquid/filters/core_filters.rb
+++ b/lib/dugway/liquid/filters/core_filters.rb
@@ -127,19 +127,12 @@ module Dugway
         id    ||= field
         case field
         when 'message'
-          text_area_tag(field, contact['message'], :id => id, :class => class_name, :tabindex => contact_tab_index)
+          text_area_tag(field, contact['message'], :id => id, :class => class_name)
         when 'captcha'
-          text_field_tag('captcha', '', :id => id, :class => class_name, :tabindex => contact_tab_index)
+          text_field_tag('captcha', '', :id => id, :class => class_name)
         else
-          text_field_tag(field, contact[field], :id => id, :class => class_name, :tabindex => contact_tab_index)
+          text_field_tag(field, contact[field], :id => id, :class => class_name)
         end
-      end
-
-      private
-
-      def contact_tab_index
-        @contact_tab_index ||= 0
-        @contact_tab_index += 1
       end
     end
   end

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169763821

Accessibility best practices dictate that elements should not have tabindex greater than zero. Using tabindex with a value greater than 0 creates an unexpected tab order, making the page less intuitive and can give the appearance of skipping certain elements entirely. This removes tabindex from the contact fieldds and relies on the page's default tab order.

Resources: 
https://dequeuniversity.com/rules/axe/3.3/tabindex?application=AxeChrome