### PR TITLE
Add ContactDrop#recaptcha

### DIFF
--- a/lib/dugway/liquid/drops/contact_drop.rb
+++ b/lib/dugway/liquid/drops/contact_drop.rb
@@ -21,6 +21,15 @@ module Dugway
         %{<img id="captcha_image" src="https://s3.amazonaws.com/bigcartel/captcha/28e3d1288cbc70c0cd1a2d10845f8e11e1a90d14.png">}
       end
 
+      def recaptcha
+        @recaptcha ||= begin
+          html = "This site is protected by reCAPTCHA and the Google "
+          html += '<a href="https://policies.google.com/privacy">Privacy Policy</a> and '
+          html += '<a href="https://policies.google.com/terms">Terms of Service</a> apply.'
+          html
+        end
+      end
+
       def sent
         request.path == '/contact' && request.post? && errors.blank?
       end

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "0.12.3"
+  VERSION = "1.0.0"
 end

--- a/spec/units/dugway/liquid/drops/contact_drop_spec.rb
+++ b/spec/units/dugway/liquid/drops/contact_drop_spec.rb
@@ -13,7 +13,7 @@ describe Dugway::Drops::ContactDrop do
     Rack::MockRequest::DEFAULT_ENV.update({
     'PATH_INFO' => '/contact'
   })}
-  
+
   let(:request) { Dugway::Request.new(env) }
 
   let(:errors) {
@@ -93,6 +93,12 @@ describe Dugway::Drops::ContactDrop do
   describe "#captcha" do
     it "should return a captcha image" do
       contact.captcha.should == %{<img id="captcha_image" src="https://s3.amazonaws.com/bigcartel/captcha/28e3d1288cbc70c0cd1a2d10845f8e11e1a90d14.png">}
+    end
+  end
+
+  describe "#recaptcha" do
+    it "returns the recaptcha branding text" do
+      contact.recaptcha.should == %{This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.}
     end
   end
 


### PR DESCRIPTION
This outputs the text that the Storefront drop will output when called
to include Google's reCAPTCHA in the contact form. This does not include
the script code because there'd be no site key to load against or test.
It's purely for theme design purposes.