### PR TITLE
Update fixtures and templates to use reCAPTCHA

### DIFF
--- a/lib/dugway/cli/templates/source/contact.html
+++ b/lib/dugway/cli/templates/source/contact.html
@@ -23,13 +23,8 @@
       {{ contact | contact_input: 'message' }}
     </li>
     <li>
-      <label for="captcha">Spam check</label>
-      <p>Please enter the characters from the image.</p>
-      <div>{{ contact.captcha }}</div>
-      {{ contact | contact_input: 'captcha' }}
-    </li>
-    <li>
       <button type="submit" name="submit" title="Send us an email">Send</button>
+      <div>{{ contact.recaptcha }}</div>
     </li>
   </ul>
 </form>

--- a/lib/dugway/contact_form_validator.rb
+++ b/lib/dugway/contact_form_validator.rb
@@ -12,23 +12,17 @@ module Dugway
         'All fields are required'
       elsif param_does_not_match(:email, email_format)
         'Invalid email address'
-      elsif param_does_not_match(:captcha, captcha_format)
-        'Spam check was incorrect'
       end
     end
 
     private
 
     def required_fields
-      [ :name, :email, :subject, :message, :captcha ]
+      [ :name, :email, :subject, :message ]
     end
 
     def email_format
       /^([^@\s]+)@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})$/
-    end
-
-    def captcha_format
-      /^rQ9pC$/i
     end
 
     def param_does_not_match(param_name, regex)

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -16,18 +16,12 @@ feature 'Contact form' do
     expect(page).to have_content('Invalid email address')
   end
 
-  scenario 'with an invalid captcha' do
-    submit_contact_form(:captcha => 'blah')
-    expect(page).to have_content('Spam check was incorrect')
-  end
-
   def submit_contact_form(fields={})
     fields.reverse_merge!(
       :name => 'Joe',
       :email => 'joe@example.com',
       :subject => 'Testing',
       :message => 'Hi there',
-      :captcha => 'rQ9pC'
     )
 
     visit '/contact'
@@ -36,7 +30,6 @@ feature 'Contact form' do
     fill_in 'Email', :with => fields[:email]
     fill_in 'Subject', :with => fields[:subject]
     fill_in 'Message', :with => fields[:message]
-    fill_in 'Spam check', :with => fields[:captcha]
 
     click_button 'Send'
   end

--- a/spec/features/page_rendering_spec.rb
+++ b/spec/features/page_rendering_spec.rb
@@ -50,7 +50,7 @@ feature 'Page rendering' do
     visit '/contact'
     expect(page).to have_content('Dugway') # layout.html
     expect(page).to have_content('Contact')
-    expect(page).to have_content('Spam check')
+    expect(page).to have_content('protected by reCAPTCHA')
   end
 
   scenario 'maintenance.html' do

--- a/spec/fixtures/theme/contact.html
+++ b/spec/fixtures/theme/contact.html
@@ -23,13 +23,8 @@
       {{ contact | contact_input: 'message' }}
     </li>
     <li>
-      <label for="captcha">Spam check</label>
-      <p>Please enter the characters from the image.</p> 
-      <div>{{ contact.captcha }}</div>       
-      {{ contact | contact_input: 'captcha' }}      
-    </li>
-    <li>
       <button type="submit" name="submit" title="Send us an email">Send</button>
+      <div>{{ contact.recaptcha }}</div>
     </li>
   </ul>
 </form>

--- a/spec/units/dugway/contact_form_validator_spec.rb
+++ b/spec/units/dugway/contact_form_validator_spec.rb
@@ -11,7 +11,6 @@ describe Dugway::ContactFormValidator do
       :email => "name@example.com",
       :subject => "subject",
       :message => "message",
-      :captcha => "rQ9pc",
     }
   end
 
@@ -36,19 +35,9 @@ describe Dugway::ContactFormValidator do
       assert_required_fields_error
     end
 
-    it "returns an error for a missing captcha" do
-      validator.params[:captcha] = "   "
-      assert_required_fields_error
-    end
-
     it "returns an error for invalid email format" do
       validator.params[:email] = "foo-at-foo-dot-net"
       expect(validator.error_message).to eq "Invalid email address"
-    end
-
-    it "returns an error for incorrect captcha" do
-      validator.params[:captcha] = "oops"
-      expect(validator.error_message).to eq "Spam check was incorrect"
     end
 
     def assert_required_fields_error


### PR DESCRIPTION
This swaps out the image-based spam check for the new reCAPTCHA branding
text that exists.

How this looks in a newly generated theme:
![image](https://user-images.githubusercontent.com/928367/95382160-3bc90800-08b7-11eb-8889-6cb5eabacacf.png)
