### PR TITLE
Update Thin dependency

### DIFF
--- a/dugway.gemspec
+++ b/dugway.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency('thor', '~> 0.20.3')
   s.add_dependency('rubyzip', '~> 0.9.9')
   s.add_dependency('uglifier', '~> 4.1')
-  s.add_dependency('thin', '~> 1.7.2')
+  s.add_dependency('thin', '~> 1.8.0')
   s.add_dependency('bigcartel-theme-fonts')
   s.add_dependency('bigcartel-currency-locales')
 


### PR DESCRIPTION
It appears that there are issues with it on MacOS Big Sur, and the 1.8.0
ver of Thin has a fix for what I believe to be the issue:
https://github.com/macournoyer/thin/pull/364

Fixes https://github.com/bigcartel/dugway/issues/182

I haven't cut the 1.0.2 release, so I'll include this fix in that tag and release.