### PR TITLE
Pin BigDecimal to 1.4.x to allow for Liquid 3.x.x #to_number to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,22 @@ individually in the Big Cartel admin._
 
 ## Install
 
-Dugway is Ruby gem so you'll need to have Ruby 2.0+ installed. Ruby is
+### Install Ruby
+
+Dugway is Ruby gem so you'll need to have Ruby installed. Ruby is
 usually pre-installed on Mac OS X and Linux, and Windows users can install it
-using [RubyInstaller](http://rubyinstaller.org). From there, simply install the
-**dugway** gem from the terminal.
+using [RubyInstaller](http://rubyinstaller.org).
+
+Supported Ruby versions:
+
+- 2.3
+- 2.4
+- 2.5
+- 2.6
+
+### Install Dugway
+
+From there, simply install the **dugway** gem from the terminal.
 
 ```
 gem install dugway

--- a/dugway.gemspec
+++ b/dugway.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack-mount', '~> 0.8.3')
   s.add_dependency('activesupport', '~> 5.2')
   s.add_dependency('liquid', '~> 3.0.6')
+  s.add_dependency('bigdecimal', '~> 1.4.4')
   s.add_dependency('coffee-script', '~> 2.4.1')
   s.add_dependency('sass', '~> 3.4.25')
   s.add_dependency('sprockets', '~> 2.0')

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
Modern Rubies change how BigDecimal is instantiated, which conflicts
with Liquid 3.x.x's approach:
https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/standardfilters.rb#L296

For the time being, until we upgrade Liquid across all of Big Cartel,
this pins BigDecimal to a working version.

Also, for the time being, we're limited to certain Rubies based off of
https://github.com/ruby/bigdecimal#which-version-should-you-select

Fixes https://github.com/bigcartel-themes/ranger/issues/6