### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.6.7, 2.5.9, 2.4.10, 2.3.8]
+        ruby-version: [2.7.5, 2.6.7, 2.5.9, 2.4.10, 2.3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage
 *.sublime*
 
 .sass-cache
+
+.ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@ An overview of the changes per-version for the Dugway gem.
 
 ## [Unreleased]
 
-- Switched from Travis CI to GitHub Actions for project CI
+- Switch from Travis CI to GitHub Actions for project CI
+- Support Ruby 2.7.x

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Supported Ruby versions:
 - 2.4
 - 2.5
 - 2.6
+- 2.7
 
 ### Install Dugway
 

--- a/dugway.gemspec
+++ b/dugway.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency('bigcartel-currency-locales')
 
   s.add_development_dependency('rake', '~> 10.0.3')
-  s.add_development_dependency('rspec', '~> 2.12.0')
+  s.add_development_dependency('rspec', '~> 2.14.1')
   s.add_development_dependency('webmock', '~> 1.9.3')
   s.add_development_dependency('json_expressions', '~> 0.9.0')
   s.add_development_dependency('capybara', '~> 2.18.0')

--- a/dugway.gemspec
+++ b/dugway.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
-  s.required_ruby_version = '>= 2.3', '< 2.7'
+  s.required_ruby_version = '>= 2.3', '< 3'
   s.executables  << 'dugway'
 
   s.add_dependency('bundler')

--- a/dugway.gemspec
+++ b/dugway.gemspec
@@ -46,6 +46,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.12.0')
   s.add_development_dependency('webmock', '~> 1.9.3')
   s.add_development_dependency('json_expressions', '~> 0.9.0')
-  s.add_development_dependency('capybara', '~> 2.0.2')
+  s.add_development_dependency('capybara', '~> 2.18.0')
   s.add_development_dependency('simplecov', '~> 0.16.1')
 end

--- a/spec/units/dugway/liquid/drops/theme_drop_spec.rb
+++ b/spec/units/dugway/liquid/drops/theme_drop_spec.rb
@@ -41,8 +41,8 @@ describe Dugway::Drops::ThemeDrop do
   }
 
   before do
-    theme.stub!(:images).and_return(images)
-    theme.stub!(:image_sets).and_return(image_sets)
+    theme.stub(:images).and_return(images)
+    theme.stub(:image_sets).and_return(image_sets)
   end
 
   describe "#logo" do

--- a/spec/units/dugway/theme_spec.rb
+++ b/spec/units/dugway/theme_spec.rb
@@ -164,7 +164,7 @@ describe Dugway::Theme do
 
     describe "when missing a required file" do
       before(:each) do
-        theme.stub(:read_source_file).with('cart.html') { theme.unstub!(:read_source_file); nil }
+        theme.stub(:read_source_file).with('cart.html') { theme.unstub(:read_source_file); nil }
       end
 
       it "should not be valid" do


### PR DESCRIPTION
This gets Dugway working with Ruby 2.7.x so that it works on modern M1 MacOS machines.
