### PR TITLE
Preset styles support

### DIFF
--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -98,7 +98,6 @@ module Dugway
 
       @errors << 'Missing theme name in source/settings.json' if name.blank?
       @errors << 'Invalid theme version in source/settings.json (ex: 1.0.3)' unless !!(version =~ /\d+\.\d+\.\d+/)
-      @errors << 'Missing images in source/images' if image_files.empty?
 
       if settings['preset_styles']
         validate_preview

--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -155,22 +155,22 @@ module Dugway
     end
 
     def validate_style_references(preset)
-      font_variables = settings['fonts'].map { |font| font['variable'] }
-      color_variables = settings['colors'].map { |color| color['variable'] }
+      ['fonts', 'colors'].each do |key_type|
+        validate_keys(preset, settings[key_type], key_type)
+      end
+    end
+
+    def validate_keys(preset, settings, key_type)
+      variables = settings.map { |item| item['variable'] }
 
       preset['styles'].each do |style|
-        style_font_keys = style['fonts'].keys
-        style_color_keys = style['colors'].keys
+        style_keys = style[key_type].keys
 
-        extra_font_keys = style_font_keys - font_variables
-        missing_font_keys = font_variables - style_font_keys
-        @errors << "Extra font keys: #{extra_font_keys.join(', ')}" unless extra_font_keys.empty?
-        @errors << "Missing font keys: #{missing_font_keys.join(', ')}" unless missing_font_keys.empty?
+        extra_keys = style_keys - variables
+        missing_keys = variables - style_keys
 
-        extra_color_keys = style_color_keys - color_variables
-        missing_color_keys = color_variables - style_color_keys
-        @errors << "Extra color keys: #{extra_color_keys.join(', ')}" unless extra_color_keys.empty?
-        @errors << "Missing color keys: #{missing_color_keys.join(', ')}" unless missing_color_keys.empty?
+        @errors << "Extra #{key_type} keys: #{extra_keys.join(', ')}" unless extra_keys.empty?
+        @errors << "Missing #{key_type} keys: #{missing_keys.join(', ')}" unless missing_keys.empty?
       end
     end
 

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end

--- a/spec/fixtures/theme/settings.json
+++ b/spec/fixtures/theme/settings.json
@@ -38,13 +38,52 @@
       "variable": "header_font",
       "label": "Header Font",
       "default": "Helvetica"
-    },  
+    },
     {
       "variable": "font",
       "label": "Font",
       "default": "Georgia"
     }
   ],
+  "preset_styles": {
+    "preview": {
+      "title_font": "header_font",
+      "body_font": "font",
+      "text_color": "text_color",
+      "background_color": "background_color"
+    },
+    "presets": [
+      {
+        "group_name": "Classic",
+        "styles": [
+          {
+            "style_name": "Classic #1",
+            "fonts": {
+              "header_font": "DM Sans",
+              "font": "DM Sans"
+            },
+            "colors": {
+              "background_color": "#FFFFFF",
+              "link_color": "#111111",
+              "text_color": "#222222"
+            }
+          },
+          {
+            "style_name": "Classic #2",
+            "fonts": {
+              "header_font": "Lora",
+              "font": "Roboto"
+            },
+            "colors": {
+              "background_color": "#F7F7F7",
+              "link_color": "#222222",
+              "text_color": "#336699"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "colors": [
     {
       "variable": "background_color",

--- a/spec/fixtures/theme/settings.json
+++ b/spec/fixtures/theme/settings.json
@@ -49,7 +49,7 @@
     "preview": {
       "title_font": "header_font",
       "body_font": "font",
-      "text_color": "text_color",
+      "text_color": "link_color",
       "background_color": "background_color"
     },
     "presets": [
@@ -64,8 +64,7 @@
             },
             "colors": {
               "background_color": "#FFFFFF",
-              "link_color": "#111111",
-              "text_color": "#222222"
+              "link_color": "#111111"
             }
           },
           {
@@ -76,8 +75,7 @@
             },
             "colors": {
               "background_color": "#F7F7F7",
-              "link_color": "#222222",
-              "text_color": "#336699"
+              "link_color": "#222222"
             }
           }
         ]

--- a/spec/units/dugway/theme_spec.rb
+++ b/spec/units/dugway/theme_spec.rb
@@ -151,7 +151,7 @@ describe Dugway::Theme do
   end
 
   describe "#font_files" do
-    it "shoud return an array of all font files" do
+    it "should return an array of all font files" do
       theme.font_files.should include("fonts/icons.ttf", "fonts/icons.woff")
     end
   end

--- a/spec/units/dugway/theme_spec.rb
+++ b/spec/units/dugway/theme_spec.rb
@@ -210,28 +210,15 @@ describe Dugway::Theme do
       end
     end
 
-    describe "when missing at least one image" do
-      before(:each) do
-        theme.stub(:image_files) { [] }
-      end
-
-      it "should not be valid" do
-        theme.valid?.should be(false)
-        theme.errors.size.should == 1
-        theme.errors.first.should == 'Missing images in source/images'
-      end
-    end
-
     describe "when there are several errors" do
       before(:each) do
         theme.stub(:name) { nil }
         theme.stub(:version) { nil }
-        theme.stub(:image_files) { [] }
       end
 
       it "should return all of them" do
         theme.valid?.should be(false)
-        theme.errors.size.should == 3
+        theme.errors.size.should == 2
       end
     end
   end


### PR DESCRIPTION
Adds necessary validations for our new Preset styles picker. This change ensures that when presets are specified, all of the data is there, it's in the correct format, and it matches up with the other font/color settings in settings.json

Also makes a change to allow for an empty images folder, since themes can be packaged with 0 images.