### PR TITLE
Instant checkout support

### DIFF
--- a/lib/dugway/liquid/filters/instant_checkout_filter.rb
+++ b/lib/dugway/liquid/filters/instant_checkout_filter.rb
@@ -1,0 +1,67 @@
+module Dugway
+  module Filters
+    module InstantCheckoutFilter
+      DIV_STYLES = [
+        "border-radius: 4px",
+        "font-size: 20px",
+        "font-weight: bold"
+      ].freeze
+
+      LINK_STYLES = [
+        "border-radius: 4px",
+        "height: 100%",
+        "display: flex",
+        "padding: 10px",
+        "align-items: center",
+        "justify-content: center"
+      ].freeze
+
+      def instant_checkout_button(account, a=nil, b=nil)
+        account = @context.registers[:account]
+        theme, height = sanitize_options(a, b)
+
+        return nil unless account.instant_checkout?
+
+        div_styles = generate_div_styles(theme, height)
+        link_styles = generate_link_styles(theme)
+
+        %(<div id="instant-checkout-button" style="#{ div_styles }"><a href="https://www.bigcartel.com/resources/help/article/apple-pay" style="#{ link_styles }">Instant Checkout</a></div>)
+      end
+
+      private
+
+      def sanitize_options(a, b)
+        theme = height = nil
+
+        [a, b].each do |value|
+          theme = value if /\A(dark|light(?:-outline)?)\z/.match(value)
+          height = value if /\A\d+(px|em|\%)\z/.match(value)
+        end
+
+        return theme, height
+      end
+
+      def generate_div_styles(theme, height)
+        styles = DIV_STYLES.dup
+        styles << "border: 1px solid black" if theme == "light-outline"
+        styles << "height: #{ height }" if height
+        styles << colors(theme)
+        styles.join("; ")
+      end
+
+      def generate_link_styles(theme)
+        styles = LINK_STYLES.dup
+        styles << colors(theme)
+        styles.join("; ")
+      end
+
+      def colors(theme)
+        if theme =~ /\Alight/
+          "background-color: white; color: black"
+        else
+          "background-color: black; color: white"
+        end
+      end
+    end
+  end
+end

--- a/lib/dugway/liquifier.rb
+++ b/lib/dugway/liquifier.rb
@@ -7,6 +7,7 @@ Liquid::Template.register_filter(Dugway::Filters::CoreFilters)
 Liquid::Template.register_filter(Dugway::Filters::DefaultPagination)
 Liquid::Template.register_filter(Dugway::Filters::UrlFilters)
 Liquid::Template.register_filter(Dugway::Filters::FontFilters)
+Liquid::Template.register_filter(Dugway::Filters::InstantCheckoutFilter)
 
 Liquid::Template.register_tag(:get, Dugway::Tags::Get)
 Liquid::Template.register_tag(:paginate, Dugway::Tags::Paginate)
@@ -28,6 +29,7 @@ module Dugway
       registers = shared_registers
       registers[:category] = variables[:category]
       registers[:artist] = variables[:artist]
+      registers[:account] = Dugway.store
 
       if errors = variables.delete(:errors)
         shared_context['errors'] << errors

--- a/lib/dugway/store.rb
+++ b/lib/dugway/store.rb
@@ -127,6 +127,10 @@ module Dugway
       currency['locale']
     end
 
+    def instant_checkout?
+      Dugway.options.dig(:store, :instant_checkout) || false
+    end
+
     private
 
     def get(path)

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end


### PR DESCRIPTION
Displays a placeholder button for instant checkout on the Product Detail page. This work is based on #174 but updated to use `.dugway.json` to control it instead of an ENV var.

```
{
  "store": {
    "subdomain": "dugway",
    "instant_checkout": true
  }
}
```

<img width="669" alt="CleanShot 2024-02-08 at 15 08 51@2x" src="https://github.com/bigcartel/dugway/assets/1694061/8500ef9c-b0ce-40b1-acb6-e7e17a98f7d8">
