### PR TITLE
feat: auto restart dugway on config file change

### DIFF
--- a/dugway.gemspec
+++ b/dugway.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency('will_paginate', '~> 3.0.4')
   s.add_dependency('i18n', '1.6')
   s.add_dependency('htmlentities', '~> 4.3.1')
+  s.add_dependency('listen', '~> 3.0')
   s.add_dependency('thor', '~> 0.20.3')
   s.add_dependency('rubyzip', '~> 0.9.9')
   s.add_dependency('terser', '~> 1.1')

--- a/lib/dugway/cli/server.rb
+++ b/lib/dugway/cli/server.rb
@@ -1,4 +1,5 @@
 require 'rack'
+require 'listen'
 
 module Dugway
   module Cli
@@ -22,6 +23,13 @@ module Dugway
         :desc    => "The server to run"
 
       def start
+        listener = Listen.to('.', only: /\.dugway\.json$/) do |modified|
+          puts "Config changed, restarting server..."
+          exec "dugway server"
+        end
+
+        Thread.new { listener.start }
+
         Rack::Server.start({
           :config => File.join(Dir.pwd, 'config.ru'),
           :environment => 'none',

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end


### PR DESCRIPTION
eliminates need to kill and restart manually when you make configuration file changes to the `.dugway.json` file for a theme