### PR TITLE
chore: option to suppress warnings

### DIFF
--- a/lib/dugway.rb
+++ b/lib/dugway.rb
@@ -1,9 +1,8 @@
 # Set our encodings to ensure we're always dealing with UTF-8 data.
 # Users experiencing problems with their templates should ensure they are saved as UTF-8.
-old_verbose, $VERBOSE = $VERBOSE, nil
+$VERBOSE = nil
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-$VERBOSE = old_verbose
 
 require 'active_support/all'
 require 'i18n'

--- a/lib/dugway.rb
+++ b/lib/dugway.rb
@@ -1,8 +1,13 @@
 # Set our encodings to ensure we're always dealing with UTF-8 data.
 # Users experiencing problems with their templates should ensure they are saved as UTF-8.
-$VERBOSE = nil
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
+begin
+  original_verbose = $VERBOSE
+  $VERBOSE = nil if ENV['DUGWAY_QUIET']
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
+ensure
+  $VERBOSE = original_verbose
+end
 
 require 'active_support/all'
 require 'i18n'

--- a/lib/dugway/cli/server.rb
+++ b/lib/dugway/cli/server.rb
@@ -22,7 +22,17 @@ module Dugway
         :default => 'thin',
         :desc    => "The server to run"
 
+      class_option :suppress_warnings,
+        type: :boolean,
+        aliases: '-q',
+        default: false,
+        desc: "Suppress warnings"
+
       def start
+        if options[:suppress_warnings]
+          $VERBOSE = nil
+        end
+
         listener = Listen.to('.', only: /\.dugway\.json$/) do |modified|
           puts "Config changed, restarting server..."
           exec "dugway server"

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end


### PR DESCRIPTION
I've seen warnings continually spew in the console while Dugway is running. 

Digging into it, it seems it's from Liquid 3.0.6's internal use of `BigDecimal.new`. 

In interim, add a flag `-q` that will suppress all warnings which seems like a reasonable thing to do in interim vs working out a Liquid upgrade or patching Liquid 3.0.6.

```
/Library/Ruby/Gems/2.6.0/gems/liquid-3.0.6/lib/liquid/standardfilters.rb:296: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Library/Ruby/Gems/2.6.0/gems/liquid-3.0.6/lib/liquid/standardfilters.rb:296: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Library/Ruby/Gems/2.6.0/gems/liquid-3.0.6/lib/liquid/standardfilters.rb:296: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Library/Ruby/Gems/2.6.0/gems/liquid-3.0.6/lib/liquid/standardfilters.rb:296: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Library/Ruby/Gems/2.6.0/gems/liquid-3.0.6/lib/liquid/standardfilters.rb:296: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Library/Ruby/Gems/2.6.0/gems/liquid-3.0.6/lib/liquid/standardfilters.rb:296: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```