### PR TITLE
feat: add validation for required data attributes in theme layout file

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,6 @@ we use the **default** values from your **settings.json** file.
   },
   "background_color": "#CCCCCC",
   "show_search": true,
-  "twitter_username": "bigcartel"
+  "instagram_username": "https://instagram.com/bigcartel"
 }
 ```

--- a/lib/dugway/cli.rb
+++ b/lib/dugway/cli.rb
@@ -5,6 +5,7 @@ require 'dugway'
 require 'dugway/cli/build'
 require 'dugway/cli/create'
 require 'dugway/cli/server'
+require 'dugway/cli/validate'
 
 module Dugway
   module Cli
@@ -12,7 +13,8 @@ module Dugway
       register Create, 'create', 'create', 'Create a new Big Cartel theme'
       register Build, 'build', 'build', 'Build your Big Cartel theme for use'
       register Server, 'server', 'server', 'Run your Big Cartel theme in the browser'
-      
+      register Validate, 'validate', 'validate', 'Validate your Big Cartel theme'
+
       desc 'version', 'Show version of Dugway'
       def version
         say "Dugway #{ Dugway::VERSION }"

--- a/lib/dugway/cli/build.rb
+++ b/lib/dugway/cli/build.rb
@@ -10,6 +10,11 @@ module Dugway
         default: false,
         desc: "Skip color settings validation"
 
+      class_option 'skip-layout-attribute-validation',
+        type: :boolean,
+        default: false,
+        desc: "Skip layout file data attribute validation"
+
       def self.source_root
         File.join(Dir.pwd, 'source')
       end
@@ -19,7 +24,7 @@ module Dugway
       end
 
       def validate
-        unless theme.valid?(validate_colors: !options['skip-color-validation'])
+        unless theme.valid?(validate_colors: !options['skip-color-validation'], validate_layout_attributes: !options['skip-layout-attribute-validation'])
           theme.errors.each { |error| say(error, :red) }
           say("\nTheme is invalid", :red)
           exit(1)

--- a/lib/dugway/cli/build.rb
+++ b/lib/dugway/cli/build.rb
@@ -5,6 +5,11 @@ module Dugway
     class Build < Thor::Group
       include Thor::Actions
 
+      class_option 'skip-color-validation',
+        type: :boolean,
+        default: false,
+        desc: "Skip color settings validation"
+
       def self.source_root
         File.join(Dir.pwd, 'source')
       end
@@ -14,9 +19,10 @@ module Dugway
       end
 
       def validate
-        unless theme.valid?
+        unless theme.valid?(validate_colors: !options['skip-color-validation'])
           theme.errors.each { |error| say(error, :red) }
-          raise "Theme is invalid"
+          say("\nTheme is invalid", :red)
+          exit(1)
         end
       end
 

--- a/lib/dugway/cli/templates/dugway.tt
+++ b/lib/dugway/cli/templates/dugway.tt
@@ -22,6 +22,6 @@
   //   },
   //   "background_color": "#CCCCCC",
   //   "show_search": true,
-  //   "twitter_username": "bigcartel"
+  //   "instagram_url": "https://instagram.com/bigcartel"
   // }
 }

--- a/lib/dugway/cli/templates/source/layout.html
+++ b/lib/dugway/cli/templates/source/layout.html
@@ -94,8 +94,8 @@
     </div>
 
     <footer>
-      {% if theme.twitter_username != blank %}
-      <p><a href="http://twitter/{{ theme.twitter_username }}">Follow @{{ theme.twitter_username }}</a></p>
+      {% if theme.instagram_url != blank %}
+      <p><a href="{{ theme.instagram_url }}">Follow us on Instagram</a></p>
       {% endif %}
     </footer>
   </body>

--- a/lib/dugway/cli/templates/source/settings.json
+++ b/lib/dugway/cli/templates/source/settings.json
@@ -37,6 +37,53 @@
       "default": "Helvetica"
     }
   ],
+  "preset_styles": {
+    "preview": {
+      "header_font": "header_font",
+      "body_font": "text_font",
+      "text_color": "primary_text_color",
+      "background_color": "background_color"
+    },
+    "presets": [
+      {
+        "group_name": "Classic",
+        "styles": [
+          {
+            "style_name": "Classic #1",
+            "fonts": {
+              "header_font": "DM Sans",
+              "text_font": "DM Sans"
+            },
+            "colors": {
+              "background_color": "#FFFFFF",
+              "primary_text_color": "#000000",
+              "link_text_color": "#000000",
+              "link_hover_color": "#BF0101",
+              "button_background_color": "#000000",
+              "button_text_color": "#FFFFFF",
+              "button_hover_background_color": "#BF0101"
+            }
+          },
+          {
+            "style_name": "Classic #2",
+            "fonts": {
+              "header_font": "Lora",
+              "text_font": "Roboto"
+            },
+            "colors": {
+              "background_color": "#F7F7F7",
+              "primary_text_color": "#222222",
+              "link_text_color": "#222222",
+              "link_hover_color": "#014ABF",
+              "button_background_color": "#222222",
+              "button_text_color": "#FFFFFF",
+              "button_hover_background_color": "#014ABF"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "colors": [
     {
       "variable": "background_color",
@@ -44,9 +91,34 @@
       "default": "#FAFAFA"
     },
     {
-      "variable": "text_color",
+      "variable": "primary_text_color",
       "label": "Text Color",
       "default": "#222222"
+    },
+    {
+      "variable": "link_text_color",
+      "label": "Text Color",
+      "default": "#222222"
+    },
+    {
+      "variable": "link_hover_color",
+      "label": "Text Color",
+      "default": "#014ABF"
+    },
+    {
+      "variable": "button_background_color",
+      "label": "Text Color",
+      "default": "#222222"
+    },
+    {
+      "variable": "button_text_color",
+      "label": "Text Color",
+      "default": "#FFFFFF"
+    },
+    {
+      "variable": "button_hover_background_color",
+      "label": "Text Color",
+      "default": "#014ABF"
     }
   ],
   "options": [
@@ -74,10 +146,10 @@
       "description": "The number of products shown per page"
     },
     {
-      "variable": "twitter_username",
-      "label": "Twitter username",
+      "variable": "instagram_url",
+      "label": "Instagram URL",
       "type": "text",
-      "description": "Ex: @bigcartel"
+      "description": "Ex: https://instagram.com/bigcartel"
     }
   ]
 }

--- a/lib/dugway/cli/templates/source/stylesheets/_config.css.sass
+++ b/lib/dugway/cli/templates/source/stylesheets/_config.css.sass
@@ -1,2 +1,13 @@
-$marginSize: 30px
+$margin-size: 30px
 $border: dashed 1px #ddd
+
+$text-font: #{"{{ theme.text_font | font_family }}"}
+$header-font: #{"{{ theme.header_font | font_family }}"}
+
+$background-color: #{"{{ theme.background_color }}"}
+$primary-text-color: #{"{{ theme.primary_text_color }}"}
+$link-text-color: #{"{{ theme.link_text_color }}"}
+$link-hover-color: #{"{{ theme.link_hover_color }}"}
+$button-background-color: #{"{{ theme.button_background_color }}"}
+$button-text-color: #{"{{ theme.button_text_color }}"}
+$button-hover-background-color: #{"{{ theme.button_hover_background_color }}"}

--- a/lib/dugway/cli/templates/source/stylesheets/layout.css.sass
+++ b/lib/dugway/cli/templates/source/stylesheets/layout.css.sass
@@ -1,17 +1,17 @@
 @import 'config'
 
 body
-  background: #{"{{ theme.background_color }}"}
-  color: #{"{{ theme.text_color }}"}
-  font: 14px/1.4 normal #{"{{ theme.text_font | font_family }}"}
+  background: $background-color
+  color: $primary-text-color
+  font: 14px/1.4 normal $text-font
   margin: 100px
 
 a
-  color: #72C29B
+  color: $link-text-color
   text-decoration: none
 
   &:hover
-    color: #60AA85
+    color: $link-hover-color
 
 ul
   list-style-type: disc
@@ -20,7 +20,7 @@ ol
   list-style-type: decimal
 
 ul, ol
-  margin-left: $marginSize
+  margin-left: $margin-size
 
 ul.unstyled,
 ol.unstyled
@@ -30,20 +30,20 @@ ol.unstyled
 
 header
   border-bottom: $border
-  font-family: #{"{{ theme.header_font | font_family }}"}
-  margin-bottom: $marginSize
-  padding-bottom: $marginSize
+  font-family: $header-font
+  margin-bottom: $margin-size
+  padding-bottom: $margin-size
   text-align: center
 
   a
-    color: #666
+    color: $link-text-color
     font-size: 2.5em
 
     &:hover
-      color: #333
+      color: $link-hover-color
 
 h1, h2, h3, h4, h5
-  font-family: #{"{{ theme.header_font | font_family }}"}
+  font-family: $header-font
 
 div.wrap
   display: table
@@ -52,7 +52,7 @@ div.wrap
 aside
   border-right: $border
   display: table-cell
-  padding-right: $marginSize
+  padding-right: $margin-size
   width: 20%
 
   section
@@ -66,15 +66,15 @@ aside
       margin-bottom: .3em
 
       a
-        color: #999
+        color: $link-text-color
         font-size: .9em
 
         &:hover
-          color: #333
+          color: $link-hover-color
 
 section.content
   display: table-cell
-  padding-left: $marginSize
+  padding-left: $margin-size
   width: 80%
 
 form

--- a/lib/dugway/cli/templates/source/stylesheets/products.css.sass
+++ b/lib/dugway/cli/templates/source/stylesheets/products.css.sass
@@ -9,8 +9,8 @@ body#home, body#products
     li.product
       box-sizing: border-box
       float: left
-      padding-bottom: $marginSize
-      padding-right: $marginSize
+      padding-bottom: $margin-size
+      padding-right: $margin-size
       max-width: 30%
 
       &:nth-child(3n+1)
@@ -18,7 +18,7 @@ body#home, body#products
 
     img
       display: block
-      margin-bottom: $marginSize / 2
+      margin-bottom: $margin-size / 2
       max-width: 100%
 
     div.pagination

--- a/lib/dugway/cli/validate.rb
+++ b/lib/dugway/cli/validate.rb
@@ -8,8 +8,13 @@ module Dugway
         default: false,
         desc: "Skip color settings validation"
 
+      class_option 'skip-layout-attribute-validation',
+        type: :boolean,
+        default: false,
+        desc: "Skip layout file data attribute validation"
+
       def validate
-        unless theme.valid?(validate_colors: !options['skip-color-validation'])
+        unless theme.valid?(validate_colors: !options['skip-color-validation'], validate_layout_attributes: !options['skip-layout-attribute-validation'])
           theme.errors.each { |error| say(error, :red) }
           say("\nTheme is invalid", :red)
           exit(1)

--- a/lib/dugway/cli/validate.rb
+++ b/lib/dugway/cli/validate.rb
@@ -3,9 +3,15 @@ module Dugway
     class Validate < Thor::Group
       include Thor::Actions
 
+      class_option 'skip-color-validation',
+        type: :boolean,
+        default: false,
+        desc: "Skip color settings validation"
+
       def validate
-        unless theme.valid?
+        unless theme.valid?(validate_colors: !options['skip-color-validation'])
           theme.errors.each { |error| say(error, :red) }
+          say("\nTheme is invalid", :red)
           exit(1)
         end
         say("Theme is valid!", :green)

--- a/lib/dugway/cli/validate.rb
+++ b/lib/dugway/cli/validate.rb
@@ -1,0 +1,21 @@
+module Dugway
+  module Cli
+    class Validate < Thor::Group
+      include Thor::Actions
+
+      def validate
+        unless theme.valid?
+          theme.errors.each { |error| say(error, :red) }
+          exit(1)
+        end
+        say("Theme is valid!", :green)
+      end
+
+      private
+
+      def theme
+        @theme ||= Dugway.theme
+      end
+    end
+  end
+end

--- a/lib/dugway/config/theme_color_attribute_mappings.yml
+++ b/lib/dugway/config/theme_color_attribute_mappings.yml
@@ -1,0 +1,112 @@
+# Color attributes we require for each theme, which is important for the ThemeColorDrop in 
+# Storefront repo which we expose to sellers and 3rd party developers
+required_color_attributes:
+  - background_color
+  - primary_text_color
+  - link_text_color
+  - link_hover_color
+  - button_background_color
+  - button_text_color
+  - button_hover_background_color
+
+# Specify overrides when a theme does not use the standard color attributes
+# Indicate when an attribute is not used by setting it to ~
+Cosmos:
+  primary_text_color: text_color
+  link_text_color: text_color
+
+Foundry:
+  link_text_color: primary_text_color
+
+Good Vibes:
+  primary_text_color: primary_color
+  link_text_color: primary_color
+  link_hover_color: secondary_color
+  button_background_color: background_color
+  button_text_color: ~
+  button_hover_background_color: ~
+
+Hopscotch:
+  primary_text_color: text_color
+  link_text_color: text_color
+  link_hover_color: secondary_text_color
+  button_background_color: background_color
+  button_text_color: text_color
+  button_hover_background_color: ~
+
+Luna:
+  link_text_color: primary_text_color
+  link_hover_color: link_rollover_color
+  button_background_color: background_color
+  button_text_color: text_color
+  button_hover_background_color: button_rollover_color
+
+Lunch Break:
+  primary_text_color: text_color
+  link_text_color: text_color
+
+Neat:
+  primary_text_color: text_color
+  link_text_color: link_color
+
+Netizen:
+  primary_text_color: text_color
+  link_text_color: text_color
+  link_hover_color: ~
+  button_background_color: button_background_color
+  button_text_color: text_color
+  button_hover_background_color: ~
+
+Nova:
+  primary_text_color: text_color
+  link_text_color: link_color
+  link_hover_color: link_hover
+  button_background_color: background_color
+  button_text_color: text_color
+  button_hover_background_color: ~
+
+PickleJuice:
+  primary_text_color: text_color
+  link_text_color: link_color
+  link_hover_color: link_hover_color
+
+Ranger:
+  link_text_color: primary_text_color
+  button_hover_background_color: ~
+
+Roadie:
+  primary_text_color: text_color
+  link_text_color: text_color
+  button_text_color: button_text_color
+  button_hover_background_color: button_hover_background_color
+
+Sidecar:
+  primary_text_color: body_text_color
+  link_text_color: link_color
+
+Snacks:
+  primary_text_color: text_color
+  link_text_color: text_color
+  link_hover_color: ~
+  button_background_color: accent_background_color
+  button_text_color: accent_text_color
+  button_hover_background_color: ~
+
+Snakebite:
+  primary_text_color: primary_color
+  link_text_color: primary_color
+  link_hover_color: primary_color
+  button_background_color: primary_color
+  button_text_color: primary_color
+  button_hover_background_color: primary_color
+
+Sunscreen:
+  primary_text_color: text_color
+  link_text_color: text_color
+
+Trace:
+  link_text_color: primary_text_color
+  link_hover_color: secondary_text_color
+  button_background_color: primary_text_color
+  button_text_color: background_color
+  button_hover_background_color: primary_text_color

--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -93,7 +93,7 @@ module Dugway
       end
     end
 
-    def valid?(validate_colors: true)
+    def valid?(validate_colors: true, validate_layout_attributes: true)
       @errors = []
 
       REQUIRED_FILES.each do |file|
@@ -116,6 +116,7 @@ module Dugway
       end
 
       validate_required_color_settings if validate_colors
+      validate_required_layout_attributes if validate_layout_attributes
 
       @errors.empty?
     end
@@ -134,6 +135,23 @@ module Dugway
       unless missing_colors.empty?
         @errors << "Missing required color settings: #{missing_colors.join(', ')}"
       end
+    end
+
+    # Validate that the Layout file has expected attributes for:
+    # - data-bc-page-type on the body tag
+    # - one data-bc-hook="header" and one data-bc-hook="footer" somewhere
+    def validate_required_layout_attributes
+      layout_content = read_source_file('layout.html')
+
+      unless layout_content =~ /<body[^>]*data-bc-page-type[^>]*>/
+        @errors << "layout.html missing `data-bc-page-type` attribute on body tag"
+      end
+
+      header_hooks = layout_content.scan(/data-bc-hook=(?:"|')header(?:"|')/).size
+      footer_hooks = layout_content.scan(/data-bc-hook=(?:"|')footer(?:"|')/).size
+
+      @errors << "layout.html must have exactly one `data-bc-hook=\"header\"`" if header_hooks != 1
+      @errors << "layout.html must have exactly one `data-bc-hook=\"footer\"`" if footer_hooks != 1
     end
 
     private

--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -9,6 +9,10 @@ module Dugway
   class Theme
     REQUIRED_FILES = %w( cart.html contact.html home.html layout.html maintenance.html product.html products.html screenshot.jpg settings.json theme.css theme.js )
 
+    THEME_COLOR_ATTRIBUTE_MAPPINGS = YAML.load_file(
+      File.join(__dir__, 'config', 'theme_color_attribute_mappings.yml')
+    ).freeze
+
     attr_reader :errors
 
     def initialize(overridden_customization={})
@@ -111,7 +115,25 @@ module Dugway
         end
       end
 
+      validate_required_color_settings
+
       @errors.empty?
+    end
+
+    def validate_required_color_settings
+      required_colors_attribute_names = THEME_COLOR_ATTRIBUTE_MAPPINGS['required_color_attributes']
+
+      theme_colors = settings['colors'].map { |c| c['variable'] }
+      mappings = THEME_COLOR_ATTRIBUTE_MAPPINGS[name] || {}
+
+      missing_colors = required_colors_attribute_names.reject do |color|
+        theme_colors.include?(color) ||
+        (mappings.key?(color) && (mappings[color].nil? || theme_colors.include?(mappings[color])))
+      end
+
+      unless missing_colors.empty?
+        @errors << "Missing required color settings: #{missing_colors.join(', ')}"
+      end
     end
 
     private

--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -93,7 +93,7 @@ module Dugway
       end
     end
 
-    def valid?
+    def valid?(validate_colors: true)
       @errors = []
 
       REQUIRED_FILES.each do |file|
@@ -115,7 +115,7 @@ module Dugway
         end
       end
 
-      validate_required_color_settings
+      validate_required_color_settings if validate_colors
 
       @errors.empty?
     end

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.11"
+  VERSION = "1.0.12"
 end

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end

--- a/spec/fixtures/theme/layout.html
+++ b/spec/fixtures/theme/layout.html
@@ -11,8 +11,8 @@
     {{ head_content }}
   </head>
 
-  <body id="{{ page.permalink }}" class="{{ page.category }}">
-    <header>
+  <body id="{{ page.permalink }}" class="{{ page.category }}"  data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
+    <header data-bc-hook="header">
       <a href="/" title="{{ store.name | escape }}">{{ store.name }}</a>
     </header>
 
@@ -78,7 +78,7 @@
     {% endif %}
     </section>
 
-    <footer>
+    <footer data-bc-hook="footer">
       <div>{{ powered_by_big_cartel }}</div>
     </footer>
   </body>

--- a/spec/fixtures/theme/settings.json
+++ b/spec/fixtures/theme/settings.json
@@ -40,7 +40,7 @@
       "default": "Helvetica"
     },
     {
-      "variable": "font",
+      "variable": "text_font",
       "label": "Font",
       "default": "Georgia"
     }
@@ -48,8 +48,8 @@
   "preset_styles": {
     "preview": {
       "title_font": "header_font",
-      "body_font": "font",
-      "text_color": "link_color",
+      "body_font": "text_font",
+      "text_color": "primary_text_color",
       "background_color": "background_color"
     },
     "presets": [
@@ -60,22 +60,32 @@
             "style_name": "Classic #1",
             "fonts": {
               "header_font": "DM Sans",
-              "font": "DM Sans"
+              "text_font": "DM Sans"
             },
             "colors": {
               "background_color": "#FFFFFF",
-              "link_color": "#111111"
+              "primary_text_color": "#000000",
+              "link_text_color": "#000000",
+              "link_hover_color": "#BF0101",
+              "button_background_color": "#000000",
+              "button_text_color": "#FFFFFF",
+              "button_hover_background_color": "#BF0101"
             }
           },
           {
             "style_name": "Classic #2",
             "fonts": {
               "header_font": "Lora",
-              "font": "Roboto"
+              "text_font": "Roboto"
             },
             "colors": {
               "background_color": "#F7F7F7",
-              "link_color": "#222222"
+              "primary_text_color": "#222222",
+              "link_text_color": "#222222",
+              "link_hover_color": "#014ABF",
+              "button_background_color": "#222222",
+              "button_text_color": "#FFFFFF",
+              "button_hover_background_color": "#014ABF"
             }
           }
         ]
@@ -86,11 +96,36 @@
     {
       "variable": "background_color",
       "label": "Background",
-      "default": "#222222"
+      "default": "white"
     },
     {
-      "variable": "link_color",
-      "label": "Link Color",
+      "variable": "primary_text_color",
+      "label": "Text",
+      "default": "black"
+    },
+    {
+      "variable": "link_text_color",
+      "label": "Link text",
+      "default": "red"
+    },
+    {
+      "variable": "link_hover_color",
+      "label": "Link hover",
+      "default": "black"
+    },
+    {
+      "variable": "button_background_color",
+      "label": "Button background",
+      "default": "black"
+    },
+    {
+      "variable": "button_text_color",
+      "label": "Button text",
+      "default": "white"
+    },
+    {
+      "variable": "button_hover_background_color",
+      "label": "Button hover background",
       "default": "red"
     }
   ],

--- a/spec/fixtures/theme/stylesheets/_partial.css
+++ b/spec/fixtures/theme/stylesheets/_partial.css
@@ -1,1 +1,1 @@
-$color: #0f0;
+$background_color: #0f0;

--- a/spec/fixtures/theme/stylesheets/one.css
+++ b/spec/fixtures/theme/stylesheets/one.css
@@ -1,3 +1,3 @@
 html, body {
   height: 100%;
-  }
+}

--- a/spec/fixtures/theme/stylesheets/two.css.sass
+++ b/spec/fixtures/theme/stylesheets/two.css.sass
@@ -1,7 +1,7 @@
 @import 'partial'
 
-$link_color: #{"{{ theme.link_color }}"}
+$link_text_color: #{"{{ theme.link_text_color }}"}
 
 a
-  background: $color
-  color: $link_color
+  background: $background_color
+  color: $link_text_color

--- a/spec/units/dugway/liquid/drops/theme_drop_spec.rb
+++ b/spec/units/dugway/liquid/drops/theme_drop_spec.rb
@@ -73,19 +73,25 @@ describe Dugway::Drops::ThemeDrop do
 
   describe "#font" do
     it "should return the theme's font" do
-      theme.font.should == 'Georgia'
+      theme.text_font.should == 'Georgia'
     end
   end
 
   describe "#background_color" do
     it "should return the theme's background_color" do
-      theme.background_color.should == '#222222'
+      theme.background_color.should == 'white'
     end
   end
 
-  describe "#link_color" do
-    it "should return the theme's link_color" do
-      theme.link_color.should == 'red'
+  describe "#link_text_color" do
+    it "should return the theme's link_text_color" do
+      theme.link_text_color.should == 'red'
+    end
+  end
+
+  describe "#link_hover_color" do
+    it "should return the theme's link_hover_color" do
+      theme.link_hover_color.should == 'black'
     end
   end
 

--- a/spec/units/dugway/theme_spec.rb
+++ b/spec/units/dugway/theme_spec.rb
@@ -18,7 +18,7 @@ describe Dugway::Theme do
   describe "#fonts" do
     it "should return a hash of font settings values" do
       theme.fonts.should == {
-        'font' => 'Georgia',
+        'text_font' => 'Georgia',
         'header_font' => 'Helvetica'
       }
     end
@@ -49,11 +49,16 @@ describe Dugway::Theme do
   describe "#customization" do
     it "should return a hash of font, color, option, images and image sets settings values" do
       theme.customization.should == {
-        'background_color' => '#222222',
+        'background_color' => 'white',
         'fixed_sidebar' => true,
-        'font' => 'Georgia',
+        'text_font' => 'Georgia',
         'header_font' => 'Helvetica',
-        'link_color' => 'red',
+        'primary_text_color' => 'black',
+        'link_text_color' => 'red',
+        'link_hover_color' => 'black',
+        'button_background_color' => 'black',
+        'button_text_color' => 'white',
+        'button_hover_background_color' => 'red',
         'show_search' => false,
         'logo' => { :url => 'images/logo_bc.png', :width => 1, :height => 1 },
         'slideshow_images' => [
@@ -69,17 +74,22 @@ describe Dugway::Theme do
     describe "when there are overridden customization" do
       before(:each) do
         Dugway.stub(:theme) {
-          Dugway::Theme.new(:fixed_sidebar => false, :link_color => 'blue')
+          Dugway::Theme.new(:fixed_sidebar => false, :link_text_color => 'blue')
         }
       end
 
       it "should merge those values into the defaults" do
         theme.customization.should == {
-          'background_color' => '#222222',
+          'background_color' => 'white',
           'fixed_sidebar' => false,
-          'font' => 'Georgia',
+          'text_font' => 'Georgia',
           'header_font' => 'Helvetica',
-          'link_color' => 'blue',
+          'primary_text_color' => 'black',
+          'link_text_color' => 'blue',
+          'link_hover_color' => 'black',
+          'button_background_color' => 'black',
+          'button_text_color' => 'white',
+          'button_hover_background_color' => 'red',
           'show_search' => false,
           'logo' => { :url => 'images/logo_bc.png', :width => 1, :height => 1 },
           'slideshow_images' => [
@@ -134,7 +144,7 @@ describe Dugway::Theme do
     end
 
     it "should sprocketize and not liquify theme.css" do
-      theme.build_file('theme.css').gsub(/\s+/, '').should == %{html,body{height:100%;}a{background:#0f0;color:{{theme.link_color}};}/**/}
+      theme.build_file('theme.css').gsub(/\s+/, '').should == %{html,body{height:100%;}a{background:#0f0;color:{{theme.link_text_color}};}/**/}
     end
   end
 
@@ -227,4 +237,3 @@ describe Dugway::Theme do
     File.read(File.join(Dugway.source_dir, file_name))
   end
 end
-


### PR DESCRIPTION
To support work in themes to add `data-bc-page-type` and `data-bc-hook` attributes in the theme Layout, this PR adds required checking.  Like PR #203, this adds a way to skip validation with `--skip-layout-attribute-validation` flag on both build and validate commands.

e.g.
![image](https://github.com/user-attachments/assets/3c1007f4-b98e-41ee-9837-c16174354904)
