### PR TITLE
chore: add `window.bigcartel` object

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7.5, 2.6.7, 2.5.9, 2.4.10, 2.3.8]
+        ruby-version: [2.7.5, 2.6.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/dugway/liquifier.rb
+++ b/lib/dugway/liquifier.rb
@@ -74,7 +74,7 @@ module Dugway
         'artists' => Drops::ArtistsDrop.new(store.artists.map { |a| Drops::ArtistDrop.new(a) }),
         'products' => Drops::ProductsDrop.new(store.products.map { |p| Drops::ProductDrop.new(p) }),
         'contact' => Drops::ContactDrop.new,
-        'head_content' => head_content,
+        'head_content' => [window_bigcartel_script, head_content].join,
         'bigcartel_credit' => bigcartel_credit,
         'powered_by_big_cartel' => powered_by_big_cartel,
       }
@@ -98,6 +98,15 @@ module Dugway
       end
 
       content
+    end
+
+    def window_bigcartel_script
+      product = @request.params[:product] ? store.product(@request.params[:product]) : nil
+
+      script = "window.bigcartel = window.bigcartel || {};"
+      script << "\nwindow.bigcartel.product = #{product.to_json};" if product
+
+      "<script>#{script}</script>"
     end
 
     def bigcartel_credit

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.13"
+  VERSION = "1.0.14"
 end


### PR DESCRIPTION
- includes product info on product pages. Simplifies local theme development to match the object's existence in real stores.
- drop tests for ruby 2.3-2.5 due to being way past EOL for those versions