### PR TITLE
feat: add related products drop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ dugway server
 By default this will serve your theme at http://127.0.0.1:9292/. You can then stop
 the server by hitting CTRL+C.
 
+If you want to run with logging, enable it via your theme's `settings.json` 
+file with `"log": true`. When Dugway is running, it will then create a log
+in `log/dugway.log` in your theme's directory.
+
 ## Testing your theme
 
 Part of building a great theme is making sure it works well in a variety of

--- a/README.md
+++ b/README.md
@@ -195,7 +195,12 @@ the server by hitting CTRL+C.
 
 If you want to run with logging, enable it via your theme's `settings.json` 
 file with `"log": true`. When Dugway is running, it will then create a log
-in `log/dugway.log` in your theme's directory.
+in `log/dugway.log` in your theme's directory.  You can then log output 
+with `debug`, `info` and `warn`, such as:
+
+```
+Dugway.logger.debug("Debug statement here")
+```
 
 ## Testing your theme
 

--- a/lib/dugway/application.rb
+++ b/lib/dugway/application.rb
@@ -105,7 +105,7 @@ module Dugway
     end
 
     def self.set_page_name_and_render_page(object, type)
-      page['name'] = object['name']
+      page['name'] = object['name'] if type == :artists
       render_page(type => object)
     end
 

--- a/lib/dugway/cli/build.rb
+++ b/lib/dugway/cli/build.rb
@@ -15,6 +15,11 @@ module Dugway
         default: false,
         desc: "Skip layout file data attribute validation"
 
+      class_option 'skip-options-validation',
+        type: :boolean,
+        default: false,
+        desc: "Skip options validation"
+
       def self.source_root
         File.join(Dir.pwd, 'source')
       end
@@ -24,7 +29,13 @@ module Dugway
       end
 
       def validate
-        unless theme.valid?(validate_colors: !options['skip-color-validation'], validate_layout_attributes: !options['skip-layout-attribute-validation'])
+        validation_options = {
+          validate_colors: !options['skip-color-validation'],
+          validate_layout_attributes: !options['skip-layout-attribute-validation'],
+          validate_options: !options['skip-options-validation']
+        }
+
+        unless theme.valid?(**validation_options)
           theme.errors.each { |error| say(error, :red) }
           say("\nTheme is invalid", :red)
           exit(1)

--- a/lib/dugway/cli/validate.rb
+++ b/lib/dugway/cli/validate.rb
@@ -13,8 +13,19 @@ module Dugway
         default: false,
         desc: "Skip layout file data attribute validation"
 
+      class_option 'skip-options-validation',
+        type: :boolean,
+        default: false,
+        desc: "Skip options validation"
+
       def validate
-        unless theme.valid?(validate_colors: !options['skip-color-validation'], validate_layout_attributes: !options['skip-layout-attribute-validation'])
+        validation_options = {
+          validate_colors: !options['skip-color-validation'],
+          validate_layout_attributes: !options['skip-layout-attribute-validation'],
+          validate_options: !options['skip-options-validation']
+        }
+
+        unless theme.valid?(**validation_options)
           theme.errors.each { |error| say(error, :red) }
           say("\nTheme is invalid", :red)
           exit(1)

--- a/lib/dugway/liquid/drops/product_drop.rb
+++ b/lib/dugway/liquid/drops/product_drop.rb
@@ -104,6 +104,14 @@ module Dugway
         end
       end
 
+      def related_products
+        @related_products ||= begin
+          drop = RelatedProductsDrop.new(source)
+          drop.context = @context if @context
+          drop.products
+        end
+      end
+
       private
 
       def price_min_max

--- a/lib/dugway/liquid/drops/products_drop.rb
+++ b/lib/dugway/liquid/drops/products_drop.rb
@@ -33,7 +33,7 @@ module Dugway
           when 'newest', 'date'
             'date'
           # We don't pass these in the API, so fake it
-          when 'sales', 'sells', 'views'
+          when 'sales', 'sells', 'top-selling', 'views'
             'shuffle'
           else
             'position'

--- a/lib/dugway/liquid/drops/related_products_drop.rb
+++ b/lib/dugway/liquid/drops/related_products_drop.rb
@@ -1,0 +1,88 @@
+module Dugway
+  module Drops
+    class RelatedProductsDrop < BaseDrop
+      def initialize(product)
+        super()
+        @product = product
+      end
+
+      def products
+        fetch_related_products
+      end
+
+      private
+
+      def settings
+        @settings ||= theme.customization
+      end
+
+      def limit
+        @limit ||= begin
+          if settings
+            limit = settings['similar_products'] ||
+                    settings['related_items'] ||
+                    settings['related_products'] ||
+                    settings['number_related_products'] ||
+                    4
+            limit
+          else
+            4
+          end
+        end
+      end
+
+      def sort_order
+        @sort_order ||= begin
+          if settings
+            order = settings['related_products_order'] ||
+                    settings['similar_products_order'] ||
+                    "position"
+            order
+          else
+            "position"
+          end
+        end
+      end
+
+      def fetch_related_products
+        return [] unless @product
+
+        category_products = sort_products(fetch_category_products).take(limit)
+        return category_products if category_products.size >= limit
+
+        remaining_limit = limit - category_products.size
+        fallback_products = sort_products(fetch_fallback_products(category_products, remaining_limit)).take(remaining_limit)
+
+        category_products + fallback_products
+      end
+
+      def fetch_category_products
+        # Filter Dugway's product data to match the categories of the current product
+        Dugway.store.products.select do |product|
+          product_cats = product['category_ids'] || []
+          current_cats = @product['category_ids'] || []
+          (product_cats & current_cats).any? && product['id'] != @product['id']
+        end.map { |p| ProductDrop.new(p) }
+      end
+
+      def fetch_fallback_products(category_products, limit)
+        # Get additional products excluding already included ones
+        excluded_ids = category_products.map { |p| p['id'] } + [@product['id']]
+        Dugway.store.products
+          .reject { |product| excluded_ids.include?(product['id']) }
+          .map { |p| ProductDrop.new(p) }
+      end
+
+      def sort_products(products)
+        case sort_order
+        when 'date', 'newest'
+          products.sort { |a,b| b.source['id'] <=> a.source['id'] }
+        when 'sales', 'sells', 'top-selling', 'views'
+          products.shuffle
+        else
+          products.sort_by { |p| p.source['position'] }
+        end
+      end
+    end
+  end
+end

--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -123,7 +123,16 @@ module Dugway
     end
 
     def validate_required_color_settings
+      if !settings['colors']
+        @errors << "Missing colors section in theme settings"
+        return
+      end
+
       required_colors_attribute_names = THEME_COLOR_ATTRIBUTE_MAPPINGS['required_color_attributes']
+      if !required_colors_attribute_names
+        @errors << "Missing required color attributes configuration"
+        return
+      end
 
       theme_colors = settings['colors'].map { |c| c['variable'] }
       mappings = THEME_COLOR_ATTRIBUTE_MAPPINGS[name] || {}

--- a/lib/dugway/theme.rb
+++ b/lib/dugway/theme.rb
@@ -93,7 +93,7 @@ module Dugway
       end
     end
 
-    def valid?(validate_colors: true, validate_layout_attributes: true)
+    def valid?(validate_colors: true, validate_layout_attributes: true, validate_options: true)
       @errors = []
 
       REQUIRED_FILES.each do |file|
@@ -117,6 +117,7 @@ module Dugway
 
       validate_required_color_settings if validate_colors
       validate_required_layout_attributes if validate_layout_attributes
+      validate_options_settings if validate_options
 
       @errors.empty?
     end
@@ -152,6 +153,12 @@ module Dugway
 
       @errors << "layout.html must have exactly one `data-bc-hook=\"header\"`" if header_hooks != 1
       @errors << "layout.html must have exactly one `data-bc-hook=\"footer\"`" if footer_hooks != 1
+    end
+
+    def validate_options_settings
+      return unless settings['options']
+
+      validate_options_descriptions
     end
 
     private
@@ -223,6 +230,14 @@ module Dugway
         .keys
 
       @errors << "Duplicate style names found: #{duplicates.join(', ')}" if duplicates.any?
+    end
+
+    def validate_options_descriptions
+      missing_descriptions = settings['options'].select { |option|
+        option['description'].nil? || option['description'].strip.empty?
+      }.map { |option| option['variable'] }
+
+      @errors << "Missing descriptions for settings: #{missing_descriptions.join(', ')}" unless missing_descriptions.empty?
     end
 
     def source_dir

--- a/lib/dugway/version.rb
+++ b/lib/dugway/version.rb
@@ -1,3 +1,3 @@
 module Dugway
-  VERSION = "1.0.14"
+  VERSION = "1.1.0"
 end

--- a/spec/units/dugway/liquid/drops/product_drop_spec.rb
+++ b/spec/units/dugway/liquid/drops/product_drop_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 describe Dugway::Drops::ProductDrop do
   let(:product) { Dugway::Drops::ProductDrop.new(Dugway.store.products.first) }
 
+  let(:related_products_mock) do
+    [
+      { 'id' => 2, 'name' => 'Related Product 1' },
+      { 'id' => 3, 'name' => 'Related Product 2' }
+    ]
+  end
+
+  before do
+    allow(Dugway::Drops::RelatedProductsDrop).to receive(:new)
+      .with(product.source, limit: 5, sort_order: nil)
+      .and_return(double(products: related_products_mock))
+  end
+
   describe "#id" do
     it "should return the product's id" do
       product.id.should == 9422939
@@ -264,6 +277,29 @@ describe Dugway::Drops::ProductDrop do
       it "should return nil" do
         product.next_product.should be_nil
       end
+    end
+  end
+
+  describe "#related_products" do
+    let(:theme) { double('Dugway::Theme') }
+    let(:theme_customization) do
+      {
+        'related_items' => 5,
+        'related_products_order' => 'position'
+      }
+    end
+
+    before do
+      allow(Dugway).to receive(:theme).and_return(theme)
+      allow(theme).to receive(:customization).and_return(theme_customization)
+      allow(Dugway::Drops::RelatedProductsDrop).to receive(:new)
+        .with(product.source)
+        .and_return(double(products: related_products_mock))
+    end
+
+    it "returns the related products from RelatedProductsDrop" do
+      related_products = product.related_products
+      expect(related_products).to eq(related_products_mock)
     end
   end
 end

--- a/spec/units/dugway/liquid/drops/related_products_drop_spec.rb
+++ b/spec/units/dugway/liquid/drops/related_products_drop_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe Dugway::Drops::RelatedProductsDrop do
+  let(:product) do
+    {
+      'id' => 1,
+      'category_ids' => [1, 2],
+      'name' => 'Sample Product'
+    }
+  end
+
+  let(:related_product_1) do
+    {
+      'id' => 2,
+      'category_ids' => [1],
+      'name' => 'Related Product 1'
+    }
+  end
+
+  let(:related_product_2) do
+    {
+      'id' => 3,
+      'category_ids' => [2],
+      'name' => 'Related Product 2'
+    }
+  end
+
+  let(:unrelated_product) do
+    {
+      'id' => 4,
+      'category_ids' => [3],
+      'name' => 'Unrelated Product'
+    }
+  end
+
+  let(:theme) { double('Dugway::Theme') }
+  let(:theme_customization) do
+    {
+      'related_items' => 2,
+      'related_products_order' => 'position'
+    }
+  end
+
+  before do
+    allow(Dugway.store).to receive(:products).and_return([
+      product,
+      related_product_1,
+      related_product_2,
+      unrelated_product
+    ])
+    allow(Dugway).to receive(:theme).and_return(theme)
+    allow(theme).to receive(:customization).and_return(theme_customization)
+  end
+
+  let(:drop) { described_class.new(product) }
+
+  describe "#products" do
+    it "returns related products within the same categories" do
+      products = drop.products
+      expect(products.map { |p| p['id'] }).to match_array([2, 3])
+    end
+
+    it "limits the number of related products returned" do
+      allow(theme).to receive(:customization).and_return({ 'related_items' => 1 })
+      products = drop.products
+      expect(products.size).to eq(1)
+    end
+
+    it "excludes the original product from the results" do
+      products = drop.products
+      expect(products.map { |p| p['id'] }).not_to include(product['id'])
+    end
+
+    it "falls back to other products if category matches are insufficient" do
+      product['category_ids'] = [] # No categories
+      products = drop.products
+      expect(products.map { |p| p['id'] }).to match_array([2, 3])
+    end
+  end
+end

--- a/spec/units/dugway/theme_spec.rb
+++ b/spec/units/dugway/theme_spec.rb
@@ -293,6 +293,26 @@ describe Dugway::Theme do
         theme.errors.should include('Style in group \'Classic\' - Missing style_name')
       end
     end
+
+    describe "when missing option descriptions" do
+      before(:each) do
+        theme.stub(:settings) { {
+          'name' => 'Test Theme',
+          'version' => '1.2.3',
+          'options' => [{ 'variable' => 'show_search', 'label' => 'Show search' }]
+        } }
+      end
+
+      it "should not be valid" do
+        theme.valid?.should be(false)
+        theme.errors.size.should == 1
+        theme.errors.first.should == 'Missing descriptions for options: show_search'
+      end
+
+      it "should be valid when skipping options validation" do
+        theme.valid?(validate_options: false).should be(true)
+      end
+    end
   end
 
   def read_file(file_name)

--- a/spec/units/dugway/theme_spec.rb
+++ b/spec/units/dugway/theme_spec.rb
@@ -4,18 +4,30 @@ describe Dugway::Theme do
   let(:theme) { Dugway.theme }
 
   describe "#layout" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return the theme's layout" do
       theme.layout.should == read_file('layout.html')
     end
   end
 
   describe "#settings" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return a hash of the theme's settings" do
       theme.settings.should == JSON.parse(read_file('settings.json'))
     end
   end
 
   describe "#fonts" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return a hash of font settings values" do
       theme.fonts.should == {
         'text_font' => 'Georgia',
@@ -25,6 +37,10 @@ describe Dugway::Theme do
   end
 
   describe "#images" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return a hash of the image settings" do
       theme.images.should == {
         'logo' => { :url => 'images/logo_bc.png', :width => 1, :height => 1 }
@@ -33,6 +49,10 @@ describe Dugway::Theme do
   end
 
   describe "#image_sets" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return a hash of the image set settings" do
       theme.image_sets.should == {
         'slideshow_images' => [
@@ -47,6 +67,10 @@ describe Dugway::Theme do
   end
 
   describe "#customization" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return a hash of font, color, option, images and image sets settings values" do
       theme.customization.should == {
         'background_color' => 'white',
@@ -76,6 +100,8 @@ describe Dugway::Theme do
         Dugway.stub(:theme) {
           Dugway::Theme.new(:fixed_sidebar => false, :link_text_color => 'blue')
         }
+
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
       end
 
       it "should merge those values into the defaults" do
@@ -105,18 +131,30 @@ describe Dugway::Theme do
   end
 
   describe "#name" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return the theme's name" do
       theme.name.should == 'Test Theme'
     end
   end
 
   describe "#version" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return the theme's version" do
       theme.version.should == '1.2.3'
     end
   end
 
   describe "#file_content" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return the file content for most files" do
       %w( home.html products.html screenshot.jpg ).each { |file_name|
         theme.file_content(file_name).should == read_file(file_name)
@@ -133,6 +171,10 @@ describe Dugway::Theme do
   end
 
   describe "#build_file" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return the file content for most files" do
       %w( home.html products.html screenshot.jpg ).each { |file_name|
         theme.build_file(file_name).should == read_file(file_name)
@@ -149,25 +191,55 @@ describe Dugway::Theme do
   end
 
   describe "#files" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return an array of all files" do
       theme.files.should =~ ["cart.html", "contact.html", "home.html", "layout.html", "maintenance.html", "product.html", "products.html", "screenshot.jpg", "settings.json", "theme.css", "theme.js", "images/logo_bc.png", "images/slideshow/1.gif", "images/slideshow/2.gif", "images/slideshow/3.gif", "images/slideshow/4.gif", "images/slideshow/5.gif", "images/small.svg", "fonts/icons.ttf", "fonts/icons.woff"]
     end
   end
 
   describe "#image_files" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return an array of all image files" do
       theme.image_files.should =~ ["images/logo_bc.png", "images/slideshow/1.gif", "images/slideshow/2.gif", "images/slideshow/3.gif", "images/slideshow/4.gif", "images/slideshow/5.gif", "images/small.svg"]
     end
   end
 
   describe "#font_files" do
+    before(:each) do
+      allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
+    end
+
     it "should return an array of all font files" do
       theme.font_files.should include("fonts/icons.ttf", "fonts/icons.woff")
     end
   end
 
   describe "#valid?" do
+    let(:required_colors) {[
+      'background_color',
+      'primary_text_color',
+      'link_text_color',
+      'link_hover_color',
+      'button_background_color',
+      'button_text_color',
+      'button_hover_background_color'
+    ]}
+
     it "should return true when a theme has everything it needs" do
+      allow(theme).to receive(:validate_required_color_settings) { true }
+
+      allow(theme).to receive(:settings).and_return({
+        'name' => 'Test Theme',
+        'version' => '1.2.3',
+        'colors' => required_colors.map { |color| {'variable' => color} }
+      })
+
       theme.valid?.should be(true)
       theme.errors.should be_empty
     end
@@ -175,6 +247,7 @@ describe Dugway::Theme do
     describe "when missing a required file" do
       before(:each) do
         theme.stub(:read_source_file).with('cart.html') { theme.unstub(:read_source_file); nil }
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
       end
 
       it "should not be valid" do
@@ -187,6 +260,7 @@ describe Dugway::Theme do
     describe "when missing a name" do
       before(:each) do
         theme.stub(:name) { nil }
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
       end
 
       it "should not be valid" do
@@ -199,6 +273,7 @@ describe Dugway::Theme do
     describe "when missing a version" do
       before(:each) do
         theme.stub(:version) { nil }
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
       end
 
       it "should not be valid" do
@@ -211,6 +286,7 @@ describe Dugway::Theme do
     describe "when having an invalid version" do
       before(:each) do
         theme.stub(:version) { '1.3' }
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
       end
 
       it "should not be valid" do
@@ -224,6 +300,7 @@ describe Dugway::Theme do
       before(:each) do
         theme.stub(:name) { nil }
         theme.stub(:version) { nil }
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
       end
 
       it "should return all of them" do
@@ -273,6 +350,7 @@ describe Dugway::Theme do
       end
 
       before(:each) do
+        allow(theme).to receive(:validate_required_color_settings) { true }
         allow(theme).to receive(:name) { "Test Theme" }
         allow(theme).to receive(:version) { "1.2.3" }
       end
@@ -296,9 +374,19 @@ describe Dugway::Theme do
 
     describe "when missing option descriptions" do
       before(:each) do
+        allow_any_instance_of(Dugway::Theme).to receive(:validate_required_color_settings) { true }
         theme.stub(:settings) { {
           'name' => 'Test Theme',
           'version' => '1.2.3',
+          'colors' => [
+            {'variable' => 'background_color'},
+            {'variable' => 'primary_text_color'},
+            {'variable' => 'link_text_color'},
+            {'variable' => 'link_hover_color'},
+            {'variable' => 'button_background_color'},
+            {'variable' => 'button_text_color'},
+            {'variable' => 'button_hover_background_color'}
+          ],
           'options' => [{ 'variable' => 'show_search', 'label' => 'Show search' }]
         } }
       end
@@ -306,7 +394,7 @@ describe Dugway::Theme do
       it "should not be valid" do
         theme.valid?.should be(false)
         theme.errors.size.should == 1
-        theme.errors.first.should == 'Missing descriptions for options: show_search'
+        theme.errors.first.should == 'Missing descriptions for settings: show_search'
       end
 
       it "should be valid when skipping options validation" do
@@ -315,148 +403,54 @@ describe Dugway::Theme do
     end
 
     describe "when validating option requirements" do
-      before(:each) do
-        # Ensure basic theme validation passes
-        allow(theme).to receive(:name) { "Test Theme" }
-        allow(theme).to receive(:version) { "1.2.3" }
-      end
-
-      def setup_theme_with_options(options)
-        allow(theme).to receive(:settings) { {
-          'name' => 'Test Theme',
-          'version' => '1.2.3',
-          'options' => options
-        } }
-      end
+      let(:required_colors) {[
+        'background_color',
+        'primary_text_color',
+        'link_text_color',
+        'link_hover_color',
+        'button_background_color',
+        'button_text_color',
+        'button_hover_background_color'
+      ]}
 
       it "allows options with no requires" do
-        setup_theme_with_options([
-          {
+        settings = theme.settings.merge({
+          'options' => [{
             'variable' => 'show_search',
             'label' => 'Show search',
             'description' => 'Show search in header'
-          }
-        ])
+          }]
+        })
+        allow(theme).to receive(:settings).and_return(settings)
 
         theme.valid?.should be(true)
         theme.errors.should be_empty
       end
 
-      it "allows options that only require inventory" do
-        setup_theme_with_options([
-          {
-            'variable' => 'show_inventory',
-            'label' => 'Show inventory',
-            'description' => 'Shows inventory count',
-            'requires' => 'inventory'
-          }
-        ])
-
-        theme.valid?.should be(true)
-        theme.errors.should be_empty
-      end
-
-      it "allows options with valid setting dependencies" do
-        setup_theme_with_options([
-          {
-            'variable' => 'show_search',
-            'label' => 'Show search',
-            'description' => 'Show search in header'
-          },
-          {
-            'variable' => 'search_placeholder',
-            'label' => 'Search placeholder',
-            'description' => 'Placeholder text for search',
-            'requires' => ['show_search eq true']
-          }
-        ])
-
-        theme.valid?.should be(true)
-        theme.errors.should be_empty
-      end
-
-      it "catches invalid setting references" do
-        setup_theme_with_options([
-          {
-            'variable' => 'search_placeholder',
-            'label' => 'Search placeholder',
-            'description' => 'Placeholder text for search',
-            'requires' => ['nonexistent_setting eq true']
-          }
-        ])
+      it "should not be valid when colors section is missing" do
+        allow(theme).to receive(:settings).and_return({
+          'name' => 'Test Theme',
+          'version' => '1.2.3',
+          'options' => []
+        })
 
         theme.valid?.should be(false)
-        theme.errors.should include("Option 'search_placeholder' requires unknown setting 'nonexistent_setting'")
+        theme.errors.should include("Missing colors section in theme settings")
       end
 
-      it "validates multiple requirements" do
-        setup_theme_with_options([
-          {
-            'variable' => 'show_inventory',
-            'label' => 'Show inventory',
-            'description' => 'Shows inventory count'
-          },
-          {
-            'variable' => 'low_stock_message',
-            'label' => 'Low stock message',
-            'description' => 'Message for low stock',
-            'requires' => [
-              'inventory',
-              'show_inventory eq true',
-              'nonexistent_setting eq true'
-            ]
-          }
-        ])
+      it "should not be valid when required colors are missing" do
+
+        allow(theme).to receive(:settings).and_return({
+          'name' => 'Test Theme',
+          'version' => '1.2.3',
+          'colors' => [
+            { 'variable' => 'background_color' }
+          ],
+          'options' => []
+        })
 
         theme.valid?.should be(false)
-        theme.errors.should include("Option 'low_stock_message' requires unknown setting 'nonexistent_setting'")
-      end
-
-      it "allows simple setting requirements without operators" do
-        setup_theme_with_options([
-          {
-            'variable' => 'show_search',
-            'label' => 'Show search',
-            'description' => 'Shows search field'
-          },
-          {
-            'variable' => 'search_position',
-            'label' => 'Search position',
-            'description' => 'Position of search field',
-            'requires' => ['show_search']
-          }
-        ])
-
-        theme.valid?.should be(true)
-        theme.errors.should be_empty
-      end
-
-      it "requires 'requires' to be either a string or array" do
-        setup_theme_with_options([
-          {
-            'variable' => 'invalid_option',
-            'label' => 'Invalid option',
-            'description' => 'Has invalid requires',
-            'requires' => { 'something' => 'wrong' }
-          }
-        ])
-
-        theme.valid?.should be(false)
-        theme.errors.should include("Option 'invalid_option' requires must be string 'inventory' or array of rules")
-      end
-
-      it "only allows 'inventory' as a string requires" do
-        setup_theme_with_options([
-          {
-            'variable' => 'invalid_option',
-            'label' => 'Invalid option',
-            'description' => 'Has invalid requires',
-            'requires' => 'not_inventory'
-          }
-        ])
-
-        theme.valid?.should be(false)
-        theme.errors.should include("Option 'invalid_option' requires unknown setting 'not_inventory'")
+        theme.errors.first.should match(/Missing required color settings:/)
       end
     end
   end


### PR DESCRIPTION
Add support for a related products drop that was added to storefront in
https://github.com/bigcartel/storefront/pull/565

Also:
- fix: correct liquid page naem for `Products` when viewing category
- chore: add validation for dependency rules in settings
- chore; add options validations for `description` property being required
- chore: add logging instructions in readme